### PR TITLE
Style issue fixed for Over Ons page making background white in lightmode

### DIFF
--- a/style.css
+++ b/style.css
@@ -369,11 +369,6 @@ footer img {
 /* Over Ons page */
 .wie-zijn-wij-box {
 	flex-direction: row-reverse;
-	background-color: white;
-}
-
-.missie-visie-box {
-	background-color: white;
 }
 
 #over-ons-container h1 {


### PR DESCRIPTION
When using lightmode the Over Ons page will show white text with a white background.
This commit fixes that issue by removing the unnessicary styling.