### PR TITLE
Created language switcher

### DIFF
--- a/php/Shared/Language/Language.php
+++ b/php/Shared/Language/Language.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Language class voor het beheren van meertalige ondersteuning in een PHP-toepassing.
+ * Deze class laadt taalbestanden op basis van de ingestelde taal en biedt een methode
+ */
+class Language
+{
+    private array $languages = ["en", "nl"];
+    private array $translations = [];
+
+    public function __construct(private string $default = 'nl')
+    {
+        // Start de sessie als die nog niet bestaat
+        if (!isset($_SESSION)) {
+            session_start();
+        }
+
+        // Stel de taal in (afhankelijk van query of sessie)
+        $this->setLanguage($default);
+    }
+    /**
+     * Stelt de huidige taal in, op basis van de URL (GET['lang']) of sessie.
+     * Als geen taal is opgegeven en geen sessie bestaat, wordt de standaardtaal gebruikt.
+     */
+    public function setLanguage(string $default = "nl"): void
+    {
+        if (isset($_GET['lang']) && in_array($_GET['lang'], $this->languages)) {
+            $_SESSION['language'] = $_GET['lang'];
+        } elseif (!isset($_SESSION['language'])) {
+            $_SESSION['language'] = $default;
+        }
+        // Laad de vertalingen voor de huidige taal
+        $this->loadLanguageFile();
+    }
+
+    /**
+     * Haalt de momenteel ingestelde taal op uit de sessie.
+     */
+    public function getLanguage(): string
+    {
+        return $_SESSION['language'] ?? $this->default;
+    }
+
+    /**
+     * Zoekt de vertaling op voor een gegeven sleutel.
+     * Ondersteunt geneste sleutels met een puntnotatie, bijv. "title" of "nav.services". 
+     */
+    public function translate(string $key): string
+    {
+        // Controleer of het een geneste sleutel is
+        if (str_contains($key, '.')) {
+            $parts = explode('.', $key);    // Splitst bijvoorbeeld "auth.login" in ['auth', 'login']
+            $current = $this->translations; // Start bij de volledige vertalingsarray
+
+            if (empty($parts)) {
+                return $key; // als de sleutel leeg is, geef de originele sleutel terug
+            }
+
+            // Loop door elk deel van de sleutel en navigeer door de array
+            foreach ($parts as $part) {
+                if (isset($current[$part])) {
+                    if (!is_array($current)) return $key; // Als de huidige waarde geen array is, maar we verwachten er een, geef de sleutel terug
+                    $current = $current[$part]; // Ga een niveau dieper
+                } else {
+                    return $key; // Sleutel niet gevonden
+                }
+            }
+
+            // Uiteindelijk gevonden waarde teruggeven
+            return $current;
+        }
+        // Geen geneste sleutel; geef directe vertaling of fallback terug
+        return $this->translations[$key] ?? $key;
+    }
+
+    /**
+     * Laadt het taalbestand op basis van de ingestelde taal.
+     * Het bestand moet een array met vertalingen returnen.
+     */
+    private function loadLanguageFile(): void
+    {
+        $language = $this->getLanguage();
+        if (!in_array($language, $this->languages)) {
+            $language = $this->default;
+        }
+        $filePath = __DIR__ . "/{$language}.php";
+        if (file_exists($filePath)) {
+            $this->translations = require $filePath;
+        } else {
+            $this->translations = [];
+        }
+    }
+}

--- a/php/Shared/Language/Language.php
+++ b/php/Shared/Language/Language.php
@@ -39,7 +39,7 @@ class Language
      */
     public function getLanguage(): string
     {
-        return $_SESSION['language'] ?? $this->default;
+        return $_SESSION['language'] ?? $this->default; // Retourneert de taal uit de sessie of de standaardtaal
     }
 
     /**
@@ -50,7 +50,7 @@ class Language
     {
         // Controleer of het een geneste sleutel is
         if (str_contains($key, '.')) {
-            $parts = explode('.', $key);    // Splitst bijvoorbeeld "auth.login" in ['auth', 'login']
+            $parts = explode('.', $key);    // Splitst bijvoorbeeld "nav.services" in ['nav', 'services']
             $current = $this->translations; // Start bij de volledige vertalingsarray
 
             if (empty($parts)) {
@@ -81,14 +81,15 @@ class Language
     private function loadLanguageFile(): void
     {
         $language = $this->getLanguage();
-        if (!in_array($language, $this->languages)) {
+        if (!in_array($language, $this->languages)) { // Controleer of de taal geldig is
+            // Als de taal niet geldig is, gebruik de standaardtaal
             $language = $this->default;
         }
-        $filePath = __DIR__ . "/{$language}.php";
-        if (file_exists($filePath)) {
-            $this->translations = require $filePath;
+        $filePath = __DIR__ . "/{$language}.php"; // Pad naar het taalbestand
+        if (file_exists($filePath)) { // Controleer of het bestand bestaat
+            $this->translations = require $filePath; // Laad de vertalingen uit het bestand
         } else {
-            $this->translations = [];
+            $this->translations = []; // Als het bestand niet bestaat, gebruik een lege array
         }
     }
 }

--- a/php/Shared/Language/en.php
+++ b/php/Shared/Language/en.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+    'nav' => [
+        'services' => 'Services',
+        'about' => 'About Us',
+        'contact' => 'Contact',
+        'dashboard' => 'Dashboard',
+        'profile' => 'Profile',
+        'logout' => 'Logout',
+        'login' => 'Login',
+    ],
+    "home" => [
+        "banner" => [
+            "text" => "Ready to move on from boring corporate outings or team-building activities? Look no further than Connect & Play!",
+            "button" => "Contact Us"
+        ],
+        "services" => [
+            "read_more" => "Read more...",
+            "videogames" => [
+                "title" => "Videogames",
+                "text" => "Dive into the world of video games, where strategy and action meet. Discover the latest releases and classic favorites, from single-player adventures to multiplayer games for all ages."
+            ],
+            "board_games" => [
+                "title" => "Board Games",
+                "text" => "Gather your friends and family for a fun game night! From strategic board games to fast-paced card games, there's something for everyone. Check out our top recommendations."
+            ],
+            "tournaments" => [
+                "title" => "Tournaments",
+                "text" => "Test your skills in our exciting tournaments! Join video game or board game competitions and prove that you are the champion. Everyone is welcome, from beginner to expert."
+            ]
+        ],
+        "usp" => [
+            "speed" => [
+                "title" => "Speed & Convenience",
+                "text" => "Delivered within 30 minutes, or it's free—guaranteed."
+            ],
+            "quality" => [
+                "title" => "Quality Guarantee",
+                "text" => "We guarantee that our products will last a lifetime, or we will replace them for free."
+            ],
+            "environment" => [
+                "title" => "Environmentally Friendly & Sustainable",
+                "text" => "100% environmentally friendly products, sustainably and ethically produced."
+            ],
+            "customer_service" => [
+                "title" => "Excellent Customer Service",
+                "text" => "24/7 available, with real people always ready to help you when you need us."
+            ]
+        ]
+    ]
+];

--- a/php/Shared/Language/nl.php
+++ b/php/Shared/Language/nl.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+    "nav" => [
+        "services" => "Diensten",
+        "about" => "Over Ons",
+        "contact" => "Contact",
+        "dashboard" => "Dashboard",
+        "profile" => "Profiel",
+        "logout" => "Log uit",
+        "login" => "Log in",
+    ],
+    "home" => [
+        "banner" => [
+            "text" => "Klaar met van die saaie bedrijfuitjes of teambuildingactiviteiten? Kijk niet verder dan Connect & Play!",
+            "button" => "Neem contact op"
+        ],
+        "services" => [
+            "read_more" => "Lees meer...",
+            "videogames" => [
+                "title" => "Videogames",
+                "text" => "Duik in de wereld van videogames, waar strategie en actie elkaar ontmoeten. Ontdek de nieuwste releases en de klassieke favorieten, van singleplayer avonturen tot multiplayer games voor alle leeftijden"
+            ],
+            "board_games" => [
+                "title" => "Bordspellen",
+                "text" => "Verzamel je vrienden en familie voor een gezellige spelavond! Van strategische bordspellen tot snelle kaartspellen, er is voor ieder wat wils. Ontdek onze topaanbevelingen."
+            ],
+            "tournaments" => [
+                "title" => "Toernooien",
+                "text" => "Test je vaardigheden in onze spannende toernooien! Doe mee met videogame- of bordspelcompetities en bewijs dat jij de kampioen bent. Iedereen is welkom, van beginner tot expert."
+            ]
+        ],
+        "usp" => [
+            "speed" => [
+                "title" => "Snelheid & Gemak",
+                "text" => "Binnen 30 minuten geleverd, of het is gratis—gegarandeerd."
+            ],
+            "quality" => [
+                "title" => "Kwaliteitsgarantie",
+                "text" => "We garanderen dat onze producten een leven lang meegaan, of we vervangen ze gratis."
+            ],
+            "environment" => [
+                "title" => "Milieuvriendelijk & Duurzaam",
+                "text" => "100% milieuvriendelijke producten, duurzaam en ethisch verantwoord geproduceerd.."
+            ],
+            "customer_service" => [
+                "title" => "Uitstekende klantenservice",
+                "text" => "24/7 beschikbaar, met echte mensen die altijd klaarstaan om je te helpen wanneer je ons nodig hebt. "
+            ]
+        ]
+    ]
+];

--- a/php/Shared/header.php
+++ b/php/Shared/header.php
@@ -4,10 +4,10 @@ require_once '/var/www/php/Profile/DataAccess/UserRepository.php';
 require_once '/var/www/php/Shared/Language/Language.php';
 
 $language = new Language();
-function __($key): string
+function __($key): string // verkorte versie voor de vertaal functie
 {
-    global $language;
-    return $language->translate($key);
+    global $language; // gebruik de globale $language variabele
+    return $language->translate($key); // vertaal de sleutel naar de huidige taal
 }
 
 

--- a/php/Shared/header.php
+++ b/php/Shared/header.php
@@ -1,10 +1,15 @@
 <?php
 require_once '/var/www/php/Shared/debug.php';
 require_once '/var/www/php/Profile/DataAccess/UserRepository.php';
+require_once '/var/www/php/Shared/Language/Language.php';
 
-// start de sessie om te kijken of de gebruiker is ingelogd
-// note: sessie moet gestart worden voordat er html wordt geprint
-session_start();
+$language = new Language();
+function __($key): string
+{
+    global $language;
+    return $language->translate($key);
+}
+
 
 // check of userId in de sessie zit
 if (isset($_SESSION["userId"])) {
@@ -49,17 +54,22 @@ if (isset($_SESSION["userId"])) {
             </a>
 
             <div id="page-links" class="flex offset mb-col-12">
-                <a href="/diensten.php">Diensten</a>
-                <a href="/over-ons.php">Over Ons</a>
-                <a href="/contact.php">Contact</a>
+                <a href="/diensten.php"><?= __('nav.services') ?></a>
+                <a href="/over-ons.php"><?= __('nav.about') ?></a>
+                <a href="/contact.php"><?= __('nav.contact') ?></a>
                 <?php if (isset($user)): ?>
-                        <?php if ($user->getRole() === UserRole::EMPLOYEE || $user->getRole() === UserRole::ADMINISTRATOR): ?>
-                        <a href="/dashboard.php">Dashboard</a>
+                    <?php if ($user->getRole() === UserRole::EMPLOYEE || $user->getRole() === UserRole::ADMINISTRATOR): ?>
+                        <a href="/dashboard.php"><?= __('nav.dashboard') ?></a>
                     <?php endif; ?>
-                    <a href="/profiel.php">Profiel</a>
-                    <a href="/logout.php">Logout</a>
+                    <a href="/profiel.php"><?= __('nav.profile') ?></a>
+                    <a href="/logout.php"><?= __('nav.logout') ?></a>
                 <?php else: ?>
-                    <a href="/login.php">Login</a>
+                    <a href="/login.php"><?= __('nav.login') ?></a>
+                <?php endif; ?>
+                <?php if($language->getLanguage() === 'nl'): ?>
+                    <a href="?lang=en">EN</a>
+                <?php else: ?>
+                    <a href="?lang=nl">NL</a>
                 <?php endif; ?>
             </div>
         </div>

--- a/public/index.php
+++ b/public/index.php
@@ -5,13 +5,11 @@
 		<div class="home-head-box py-50 col-6 mb-col-12 flex justify-center">
 			<h1 class="heading pb-15">Connect & Play</h1>
 			<p class="text-center pb-10 col-12">
-				Klaar met van die saaie bedrijfuitjes of
-				teambuildingactiviteiten? Kijk niet verder dan Connect &
-				Play!
+				<?= __('home.banner.text') ?>
 			</p>
 			<div class="pt-10">
 				<a class="button p-10" href="contact.html">
-					Neem contact op
+					<?= __('home.banner.button') ?>
 				</a>
 			</div>
 		</div>
@@ -25,41 +23,37 @@
 			<img class="mb-col-12 col-12" src="images/dienst_1.jpg"
 				alt="Gamer achter computer die videogames speelt" />
 			<div class="px-10 pb-10 flex justify-center">
-				<h2 class="pt-10">Videogames</h2>
+				<h2 class="pt-10">
+					<?= __('home.services.videogames.title') ?>
+				</h2>
 				<p>
-					Duik in de wereld van videogames, waar strategie en
-					actie elkaar ontmoeten. Ontdek de nieuwste releases
-					en de klassieke favorieten, van singleplayer
-					avonturen tot multiplayer games voor alle
-					leeftijden.
+					<?= __('home.services.videogames.text') ?>
 				</p>
-				<a class="home-info-button" href="diensten.html">Lees meer...</a>
+				<a class="home-info-button" href="diensten.html"><?= __('home.services.read_more') ?></a>
 			</div>
 		</div>
 		<div class="mb-col-12 col-4 flex justify-center home-info-box">
 			<img class="mb-col-12 col-12" src="images/dienst_3.jpg" alt="Bordspel" />
 			<div class="px-10 pb-10 flex justify-center">
-				<h2 class="pt-10">Bordspellen</h2>
+				<h2 class="pt-10">
+					<?= __('home.services.board_games.title') ?>
+				</h2>
 				<p>
-					Verzamel je vrienden en familie voor een gezellige
-					spelavond! Van strategische bordspellen tot snelle
-					kaartspellen, er is voor ieder wat wils. Ontdek onze
-					topaanbevelingen.
+					<?= __('home.services.board_games.text') ?>
 				</p>
-				<a class="home-info-button" href="diensten.html">Lees meer...</a>
+				<a class="home-info-button" href="diensten.html"><?= __('home.services.read_more') ?></a>
 			</div>
 		</div>
 		<div class="mb-col-12 col-4 flex justify-center home-info-box">
 			<img class="mb-col-12 col-12" src="images/dienst_4.jpg" alt="Een trofee in een arena" />
 			<div class="px-10 pb-10 flex justify-center">
-				<h2 class="pt-10">Toernooien</h2>
+				<h2 class="pt-10">
+					<?= __('home.services.tournaments.title') ?>
+				</h2>
 				<p>
-					Test je vaardigheden in onze spannende toernooien!
-					Doe mee met videogame- of bordspelcompetities en
-					bewijs dat jij de kampioen bent. Iedereen is welkom,
-					van beginner tot expert.
+					<?= __('home.services.tournaments.text') ?>
 				</p>
-				<a class="home-info-button" href="diensten.html">Lees meer...</a>
+				<a class="home-info-button" href="diensten.html"><?= __('home.services.read_more') ?></a>
 			</div>
 		</div>
 	</div>
@@ -69,50 +63,53 @@
 <section class="usp-section flex justify-center py-50">
 	<div class="col-8 flex">
 		<div class="mb-col-6 col-3 text-center">
-			<h5 class="text-center">Snelheid & Gemak</h5>
+			<h5 class="text-center">
+				<?= __('home.usp.speed.title') ?>
+			</h5>
 			<ul class="usp">
 				<li>
 					<img class="invert-color-img py-15" src="images/iconTruck.svg" alt="Vrachtwagen" />
 					<p class="tiny-text">
-						Binnen 30 minuten geleverd, of het is
-						gratis—gegarandeerd.
+						<?= __('home.usp.speed.text') ?>
 					</p>
 				</li>
 			</ul>
 		</div>
 		<div class="mb-col-6 col-3 text-center">
-			<h5>Kwaliteitsgarantie</h5>
+			<h5>
+				<?= __('home.usp.quality.title') ?>
+			</h5>
 			<ul class="usp">
 				<li>
 					<img class="invert-color-img py-15" src="images/iconAward.svg" alt="Prijs" />
 					<p class="tiny-text">
-						We garanderen dat onze producten een leven lang
-						meegaan, of we vervangen ze gratis.
+						<?= __('home.usp.quality.text') ?>
 					</p>
 				</li>
 			</ul>
 		</div>
 		<div class="mb-col-6 col-3 text-center">
-			<h5>Milieuvriendelijk & Duurzaam</h5>
+			<h5>
+				<?= __('home.usp.environment.title') ?>
+			</h5>
 			<ul class="usp">
 				<li>
 					<img class="invert-color-img py-15" src="images/iconLeaf.svg" alt="Milieu" />
 					<p class="tiny-text">
-						100% milieuvriendelijke producten, duurzaam en
-						ethisch verantwoord geproduceerd.
+						<?= __('home.usp.environment.text') ?>
 					</p>
 				</li>
 			</ul>
 		</div>
 		<div class="mb-col-6 col-3 text-center">
-			<h5>Uitstekende klantenservice</h5>
+			<h5>
+				<?= __('home.usp.customer_service.title') ?>
+			</h5>
 			<ul class="usp">
 				<li>
 					<img class="invert-color-img py-15" src="images/iconHeadset.svg" alt="Klantenservice" />
 					<p class="tiny-text">
-						24/7 beschikbaar, met echte mensen die altijd
-						klaarstaan om je te helpen wanneer je ons nodig
-						hebt.
+						<?= __('home.usp.customer_service.text') ?>
 					</p>
 				</li>
 			</ul>


### PR DESCRIPTION
### In deze PR heb ik het volgende toegevoegd en aangepast:
- Een taalwisselaar (language switcher) geïmplementeerd.
- De homepage vertaald en geschikt gemaakt voor meertalige ondersteuning.

---

#### 📝 Uitleg: vertalingen toevoegen en gebruiken

Vertalingen zijn te vinden in `/php/Shared/Language/`. Hier bevinden zich twee bestanden:
- `nl.php` – Nederlands  
- `en.php` – Engels  

Deze bestanden bevatten *associative arrays* met vertalingssleutels en bijbehorende teksten. Deze arrays kunnen zo diep genest worden als nodig.

> ⚠️ **Belangrijk:** om verwarring te voorkomen, __moeten__ alle keys Engelstalig zijn, ook in het Nederlands bestand.

Voorbeeld (`nl.php`):

```php
[
  "title" => "Connect & Play",
  "nav" => [
    "services" => "Diensten"
  ],
  "very" => [
    "nested" => [
      "example" => [
        "text" => "Zeer diep geneste tekst"
      ]
    ]
  ]
]
```
Om vertalingen in je code te gebruiken, maak je gebruik van de `__()` functie. Deze hoef je niet te importeren — hij wordt automatisch beschikbaar gesteld via `header.php`.

Voor geneste sleutels gebruik je een punt (.) tussen elk niveau. Enkele voorbeelden:
```php
<h1><?= __("title") ?></h1>
```
```php
<a href="diensten.php"><?= __("nav.services") ?></a>
```
```php
<div><?= __("very.nested.example.text") ?></div>