### PR TITLE
remove docker-compose test container order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# connect & play
+
+## runnen
+```shell
+docker compose up
+```
+
+## tests uitvoeren (na runnen)
+```shell
+docker compose --profile test up
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
         ports:
             - "8080:80" # de webserver runt op poort 8080
         depends_on:
-#            - test-php
             - mariadb
             - phpmyadmin
         volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
         ports:
             - "8080:80" # de webserver runt op poort 8080
         depends_on:
-            - test-php
+#            - test-php
             - mariadb
             - phpmyadmin
         volumes:
@@ -31,6 +31,8 @@ services:
             PMA_HOST: mariadb # dit geeft aan dat dit de container is waarop de database runt.
 
     test-php:
+        profiles:
+            - test
         build:
             dockerfile: "dockerfile-test" # gebruik de dockerfile-test als image
         depends_on:

--- a/dockerfile-test
+++ b/dockerfile-test
@@ -15,5 +15,8 @@ COPY ./public/composer.lock ./
 # installeer phpunit
 RUN composer install
 
+# Installeer PDO MySQL driver
+RUN docker-php-ext-install pdo_mysql
+
 #                       voer tests uit in map ./tests      en include deze map met onze code
 ENTRYPOINT ["composer", "exec", "phpunit", "./tests", "--", "--include-path", "\"/var/www\""]


### PR DESCRIPTION
after testing with @mastermooss the tests start before the database has finished initializing, resulting in the container crashing.

we've decided that it's easier to run the tests manually instead of adding a health check.

i've added the commands for running them in the README